### PR TITLE
Avoid ambiguity with Network.Socket.Closed

### DIFF
--- a/source/Network/Xmpp/Stream.hs
+++ b/source/Network/Xmpp/Stream.hs
@@ -37,7 +37,7 @@ import           Data.Word (Word16)
 import           Data.XML.Pickle
 import           Data.XML.Types
 import qualified GHC.IO.Exception as GIE
-import           Network.Socket hiding (Stream,connect)
+import           Network.Socket hiding (Closed, Stream, connect)
 import           Network.DNS hiding (encode, lookup)
 import qualified Network.Socket as S
 import           Network.Socket (AddrInfo)


### PR DESCRIPTION
cabal 2.2.0.0 and ghc 8.4.4 failed to build pontarius-xmpp 0.5.6.4 with network 2.6.3.6 because of a clash between Network.Sockets.Closed and Network.Xmpp.Stream.Closed.  This patch hides the former so that the ambiguity doesn't arise.