### PR TITLE
[refactoring] remove legacy crypto-random

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # 0.5.1 to 0.6.0
 * Changed roster update callback to take RosterUpdate type
 * Added onrosterPushL lens
+* Removed legacy `crypto-random` (this caused issues when compiling with GHC 9.2.5)
 
 # 0.5.0 to 0.5.1
 * Fixed input logger choking on long non-ascii messages

--- a/pontarius-xmpp.cabal
+++ b/pontarius-xmpp.cabal
@@ -1,6 +1,6 @@
 Cabal-Version: 2.2
 Name:          pontarius-xmpp
-Version:       0.5.6.5
+Version:       0.5.6.6
 Build-Type:    Simple
 License:       BSD-3-Clause
 License-File:  LICENSE.md
@@ -41,7 +41,7 @@ common stuff
                , conduit              >=1.3 && < 1.4
                , containers           >=0.4.0.0
                , crypto-api           >=0.9
-               , crypto-random        >=0.0.5
+               , cryptonite           >=0.30 && < 1.0
                , cryptohash           >=0.6.1
                , cryptohash-cryptoapi >=0.1
                , data-default         >=0.2

--- a/source/Network/Xmpp/Tls.hs
+++ b/source/Network/Xmpp/Tls.hs
@@ -11,7 +11,6 @@ import qualified       Control.Exception.Lifted as Ex
 import                 Control.Monad
 import                 Control.Monad.Except
 import                 Control.Monad.State.Strict
-import "crypto-random" Crypto.Random
 import qualified       Data.ByteString as BS
 import qualified       Data.ByteString.Char8 as BSC8
 import qualified       Data.ByteString.Lazy as BL


### PR DESCRIPTION
`crypto-random` seems unused and version 0.9 (latest) caused issues when I was compiling with GHC 9.2.5. Also, `crypto-random` repo says it's deprecated in favor of `cryptonite` which is a dependency of pontarius anyways.