### PR TITLE
Use `crypton` instead of  deprecated `cryptonite`

### DIFF
--- a/pontarius-xmpp.cabal
+++ b/pontarius-xmpp.cabal
@@ -40,9 +40,7 @@ common stuff
                , binary               >=0.4.1
                , conduit              >=1.3 && < 1.4
                , containers           >=0.4.0.0
-               , crypto-api           >=0.9
-               , cryptohash           >=0.6.1
-               , cryptohash-cryptoapi >=0.1
+               , crypton              >=1.0
                , data-default         >=0.2
                , dns                  >=3.0
                , exceptions           >=0.6
@@ -54,7 +52,7 @@ common stuff
                , mtl                  >=2.0.0.0
                , network              >=2.3.1.0
                , profunctors          >= 4
-               , pureMD5              >=2.1.2.1
+               , ram
                , random               >=1.0.0.0
                , resourcet            >=0.3.0
                , split                >=0.1.2.3

--- a/pontarius-xmpp.cabal
+++ b/pontarius-xmpp.cabal
@@ -155,6 +155,8 @@ Test-Suite tests
                , Tests.Parsers
                , Tests.Picklers
                , Tests.Stream
+               , Tests.Md5Digest
+               , Tests.SaslCrypto
   ghc-options: -O2 -fno-warn-orphans -fconstraint-solver-iterations=10
   default-language:    Haskell2010
 

--- a/pontarius-xmpp.cabal
+++ b/pontarius-xmpp.cabal
@@ -40,7 +40,7 @@ common stuff
                , binary               >=0.4.1
                , conduit              >=1.3 && < 1.4
                , containers           >=0.4.0.0
-               , crypton              >=1.0
+               , crypton              >=1.1
                , data-default         >=0.2
                , dns                  >=3.0
                , exceptions           >=0.6
@@ -189,7 +189,7 @@ Test-Suite runtests
                , xml-types
                , tasty
                , tasty-hunit
-               , tls
+               , tls >=1.3.9 && <2.4.2
   default-language:    Haskell2010
 
 benchmark benchmarks

--- a/source/Network/Xmpp/Sasl/Mechanisms/DigestMd5.hs
+++ b/source/Network/Xmpp/Sasl/Mechanisms/DigestMd5.hs
@@ -3,6 +3,9 @@
 
 module Network.Xmpp.Sasl.Mechanisms.DigestMd5
     ( digestMd5
+    , md5Hex
+    , md5Raw
+    , digestMd5Response
     ) where
 
 import           Control.Monad.Except
@@ -55,7 +58,7 @@ xmppDigestMd5 authcid' authzid' password' = do
 
             nc         = "00000001"
             digestURI  = "xmpp/" `BS.append` Text.encodeUtf8 hname
-            digest     = md5Digest
+            digest     = digestMd5Response
                 uname_
                 (lookup "realm" prs)
                 passwd_
@@ -78,33 +81,36 @@ xmppDigestMd5 authcid' authzid' password' = do
                             , ["charset"   ,       "utf-8"  ]
                             ]
             in B64.encode response
-        -- lowercase hex MD5, used in DIGEST-MD5 response
-        hash :: [BS.ByteString] -> BS.ByteString
-        hash = BS8.pack . show
-            . (Hash.hash :: BS.ByteString -> Hash.Digest Hash.MD5)
-            . BS.intercalate ":"
-        -- raw 16-byte MD5 digest, used for HA1 inner hash
-        hashRaw :: [BS.ByteString] -> BS.ByteString
-        hashRaw = BA.convert
-            . (Hash.hash :: BS.ByteString -> Hash.Digest Hash.MD5)
-            . BS.intercalate ":"
-        -- TODO: this only handles MD5-sess
-        md5Digest :: BS8.ByteString
-                  -> Maybe BS8.ByteString
-                  -> BS8.ByteString
-                  -> BS8.ByteString
-                  -> BS8.ByteString
-                  -> BS8.ByteString
-                  -> BS8.ByteString
-                  -> BS8.ByteString
-                  -> BS8.ByteString
-        md5Digest uname realm pwd digestURI nc qop nonce cnonce =
-          let ha1 = hash [ hashRaw [uname, maybe "" id realm, pwd]
-                         , nonce
-                         , cnonce
-                         ]
-              ha2 = hash ["AUTHENTICATE", digestURI]
-          in hash [ha1, nonce, nc, cnonce, qop, ha2]
+
+-- lowercase hex MD5, used in DIGEST-MD5 response
+md5Hex :: [BS.ByteString] -> BS.ByteString
+md5Hex = BS8.pack . show
+    . (Hash.hash :: BS.ByteString -> Hash.Digest Hash.MD5)
+    . BS.intercalate ":"
+
+-- raw 16-byte MD5 digest, used for HA1 inner hash
+md5Raw :: [BS.ByteString] -> BS.ByteString
+md5Raw = BA.convert
+    . (Hash.hash :: BS.ByteString -> Hash.Digest Hash.MD5)
+    . BS.intercalate ":"
+
+-- TODO: this only handles MD5-sess
+digestMd5Response :: BS8.ByteString
+          -> Maybe BS8.ByteString
+          -> BS8.ByteString
+          -> BS8.ByteString
+          -> BS8.ByteString
+          -> BS8.ByteString
+          -> BS8.ByteString
+          -> BS8.ByteString
+          -> BS8.ByteString
+digestMd5Response uname realm pwd digestURI nc qop nonce cnonce =
+  let ha1 = md5Hex [ md5Raw [uname, maybe "" id realm, pwd]
+                 , nonce
+                 , cnonce
+                 ]
+      ha2 = md5Hex ["AUTHENTICATE", digestURI]
+  in md5Hex [ha1, nonce, nc, cnonce, qop, ha2]
 
 digestMd5 :: Username -- ^ Authentication identity (authcid or username)
           -> Maybe AuthZID -- ^ Authorization identity (authzid)

--- a/source/Network/Xmpp/Sasl/Mechanisms/DigestMd5.hs
+++ b/source/Network/Xmpp/Sasl/Mechanisms/DigestMd5.hs
@@ -7,13 +7,11 @@ module Network.Xmpp.Sasl.Mechanisms.DigestMd5
 
 import           Control.Monad.Except
 import           Control.Monad.State.Strict
-import qualified Crypto.Classes as CC
-import qualified Data.Binary as Binary
-import qualified Data.ByteString as BS
+import qualified Crypto.Hash            as Hash
+import qualified Data.ByteArray         as BA
+import qualified Data.ByteString        as BS
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.ByteString.Char8 as BS8
-import qualified Data.ByteString.Lazy as BL
-import qualified Data.Digest.Pure.MD5 as MD5
 import qualified Data.List as L
 import           Data.Text (Text)
 import qualified Data.Text.Encoding as Text
@@ -80,15 +78,16 @@ xmppDigestMd5 authcid' authzid' password' = do
                             , ["charset"   ,       "utf-8"  ]
                             ]
             in B64.encode response
-        hash :: [BS8.ByteString] -> BS8.ByteString
+        -- lowercase hex MD5, used in DIGEST-MD5 response
+        hash :: [BS.ByteString] -> BS.ByteString
         hash = BS8.pack . show
-               . (CC.hash' :: BS.ByteString -> MD5.MD5Digest)
-                  . BS.intercalate (":")
-        hashRaw :: [BS8.ByteString] -> BS8.ByteString
-        hashRaw = toStrict . Binary.encode .
-            (CC.hash' :: BS.ByteString -> MD5.MD5Digest) . BS.intercalate (":")
-        toStrict :: BL.ByteString -> BS8.ByteString
-        toStrict = BS.concat . BL.toChunks
+            . (Hash.hash :: BS.ByteString -> Hash.Digest Hash.MD5)
+            . BS.intercalate ":"
+        -- raw 16-byte MD5 digest, used for HA1 inner hash
+        hashRaw :: [BS.ByteString] -> BS.ByteString
+        hashRaw = BA.convert
+            . (Hash.hash :: BS.ByteString -> Hash.Digest Hash.MD5)
+            . BS.intercalate ":"
         -- TODO: this only handles MD5-sess
         md5Digest :: BS8.ByteString
                   -> Maybe BS8.ByteString

--- a/source/Network/Xmpp/Sasl/Mechanisms/Scram.hs
+++ b/source/Network/Xmpp/Sasl/Mechanisms/Scram.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_HADDOCK hide #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -33,7 +34,9 @@ hashToken = Proxy
 
 hashBytes
   :: forall hash proxy
-   . Hash.HashAlgorithm hash
+   . ( Hash.HashAlgorithm hash
+     , BA.ByteArrayAccess (Hash.Digest hash)
+     )
   => proxy hash
   -> BS.ByteString
   -> BS.ByteString
@@ -42,7 +45,9 @@ hashBytes _ =
 
 hmacBytes
   :: forall hash proxy
-   . Hash.HashAlgorithm hash
+   . ( Hash.HashAlgorithm hash
+     , BA.ByteArrayAccess (HMAC.HMAC hash)
+     )
   => proxy hash
   -> BS.ByteString
   -> BS.ByteString
@@ -54,8 +59,11 @@ hmacBytes _ key msg =
 -- mechanism according to RFC 5802.
 --
 -- This implementation is independent and polymorphic in the used hash function.
-scram :: Hash.HashAlgorithm hash
-      => Proxy hash      -- ^ Dummy argument to determine the hash to use; you
+scram :: ( Hash.HashAlgorithm hash
+      , BA.ByteArrayAccess (Hash.Digest hash)
+      , BA.ByteArrayAccess (HMAC.HMAC hash)
+      )
+      => proxy hash      -- ^ Dummy argument to determine the hash to use; you
                          --   can safely pass undefined or a 'hashToken' to it
       -> Text.Text       -- ^ Authentication ID (user name)
       -> Maybe Text.Text -- ^ Authorization ID

--- a/source/Network/Xmpp/Sasl/Mechanisms/Scram.hs
+++ b/source/Network/Xmpp/Sasl/Mechanisms/Scram.hs
@@ -1,7 +1,9 @@
 {-# OPTIONS_HADDOCK hide #-}
 {-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Network.Xmpp.Sasl.Mechanisms.Scram
   where
@@ -10,13 +12,14 @@ import           Control.Applicative ((<$>))
 import           Control.Monad
 import           Control.Monad.Except
 import           Control.Monad.State.Strict
-import qualified Crypto.Classes          as Crypto
-import qualified Crypto.HMAC             as Crypto
-import qualified Crypto.Hash.CryptoAPI   as Crypto
+import qualified Crypto.Hash             as Hash
+import qualified Crypto.MAC.HMAC         as HMAC
+import qualified Data.ByteArray          as BA
 import qualified Data.ByteString         as BS
 import qualified Data.ByteString.Base64  as B64
 import           Data.ByteString.Char8   as BS8 (unpack)
 import           Data.List (foldl1', genericTake)
+import Data.Proxy (Proxy(..))
 import qualified Data.Text               as Text
 import qualified Data.Text.Encoding      as Text
 import           Network.Xmpp.Sasl.Common
@@ -25,15 +28,34 @@ import           Network.Xmpp.Types
 
 -- | A nicer name for undefined, for use as a dummy token to determin
 -- the hash function to use
-hashToken :: (Crypto.Hash ctx hash) => hash
-hashToken = undefined
+hashToken :: Proxy hash
+hashToken = Proxy
+
+hashBytes
+  :: forall hash proxy
+   . Hash.HashAlgorithm hash
+  => proxy hash
+  -> BS.ByteString
+  -> BS.ByteString
+hashBytes _ =
+  BA.convert . (Hash.hash :: BS.ByteString -> Hash.Digest hash)
+
+hmacBytes
+  :: forall hash proxy
+   . Hash.HashAlgorithm hash
+  => proxy hash
+  -> BS.ByteString
+  -> BS.ByteString
+  -> BS.ByteString
+hmacBytes _ key msg =
+  BA.convert (HMAC.hmac key msg :: HMAC.HMAC hash)
 
 -- | Salted Challenge Response Authentication Mechanism (SCRAM) SASL
 -- mechanism according to RFC 5802.
 --
 -- This implementation is independent and polymorphic in the used hash function.
-scram :: (Crypto.Hash ctx hash)
-      => hash            -- ^ Dummy argument to determine the hash to use; you
+scram :: Hash.HashAlgorithm hash
+      => Proxy hash      -- ^ Dummy argument to determine the hash to use; you
                          --   can safely pass undefined or a 'hashToken' to it
       -> Text.Text       -- ^ Authentication ID (user name)
       -> Maybe Text.Text -- ^ Authorization ID
@@ -55,16 +77,11 @@ scram hToken authcid authzid password = do
         unless (lookup "v" finalPairs == Just v) $ throwError AuthOtherFailure -- TODO: Log
         return ()
       where
-        -- We need to jump through some hoops to get a polymorphic solution
-        encode :: Crypto.Hash ctx hash => hash -> hash -> BS.ByteString
-        encode _hashtoken = Crypto.encode
-
         hash :: BS.ByteString -> BS.ByteString
-        hash str = encode hToken $ Crypto.hash' str
+        hash = hashBytes hToken
 
         hmac :: BS.ByteString -> BS.ByteString -> BS.ByteString
-        hmac key str = encode hToken $ Crypto.hmac' (Crypto.MacKey key) str
-
+        hmac = hmacBytes hToken
         authzid'' :: Maybe BS.ByteString
         authzid''              = (\z -> "a=" +++ Text.encodeUtf8 z) <$> authzid'
 
@@ -155,7 +172,7 @@ scramSha1 :: Username  -- ^ username
 scramSha1 authcid authzid passwd =
     ( "SCRAM-SHA-1"
     , do
-          r <- runExceptT $ scram (hashToken :: Crypto.SHA1) authcid authzid passwd
+          r <- runExceptT $ scram (Proxy :: Proxy Hash.SHA1) authcid authzid passwd
           case r of
               Left (AuthStreamFailure e) -> return $ Left e
               Left e -> return $ Right $ Just e

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -5,9 +5,13 @@ import Test.Tasty
 import Tests.Parsers
 import Tests.Picklers
 import Tests.Stream
+import Tests.SaslCrypto
+import Tests.Md5Digest
 
 main :: IO ()
 main = defaultMain $ testGroup "root" [ parserTests
                                       , picklerTests
                                       , streamTests
+                                      , saslCrypto
+                                      , digestMd5
                                       ]

--- a/tests/Tests/Md5Digest.hs
+++ b/tests/Tests/Md5Digest.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Tests.Md5Digest where
+
+import qualified Data.ByteString as BS
+import Test.Hspec
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (testCase)
+import Network.Xmpp.Sasl.Mechanisms.DigestMd5
+  ( digestMd5Response
+  , md5Hex
+  , md5Raw
+  )
+import Tests.SaslCrypto (hex)
+
+digestMd5 :: TestTree
+digestMd5 =
+  testCase "DigestMd5" $ hspec spec
+
+spec :: Spec
+spec = do
+  describe "DIGEST-MD5 crypto helpers" $ do
+    -- RFC 2831 Using Digest Authentication as a SASL Mechanism
+    -- https://www.rfc-editor.org/rfc/rfc2831.html
+    it "computes DIGEST-MD5 RFC 2831 response" $ do
+      digestMd5Response
+        "chris"
+        (Just "elwood.innosoft.com")
+        "secret"
+        "imap/elwood.innosoft.com"
+        "00000001"
+        "auth"
+        "OA6MG9tEQGm2hh"
+        "OA6MHXh6VqTrRk"
+        `shouldBe` "d388dad90d4bbd760a152321f2143af7"
+
+    -- RFC 1321 MD5 Message-Digest Algorithm
+    -- https://www.rfc-editor.org/rfc/rfc1321.txt
+    it "computes MD5 RFC 1321 hex digest" $ do
+      md5Hex ["abc"] `shouldBe` "900150983cd24fb0d6963f7d28e17f72"
+
+    it "computes MD5 raw digest bytes" $ do
+      hex (md5Raw ["abc"]) `shouldBe` "900150983cd24fb0d6963f7d28e17f72"
+
+    it "keeps md5Raw as raw bytes, not hex text" $ do
+      BS.length (md5Raw ["abc"]) `shouldBe` 16

--- a/tests/Tests/SaslCrypto.hs
+++ b/tests/Tests/SaslCrypto.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Tests.SaslCrypto
+  ( saslCrypto
+  , hex
+  ) where
+
+import qualified Crypto.Hash as Hash
+import qualified Data.ByteString as BS
+import Data.Proxy (Proxy(..))
+import Data.Word (Word8)
+import Numeric (showHex)
+import Test.Hspec
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (testCase)
+
+import Network.Xmpp.Sasl.Mechanisms.Scram
+  ( hashBytes
+  , hmacBytes
+  )
+
+saslCrypto :: TestTree
+saslCrypto =
+  testCase "SaslCrypto" $ hspec spec
+
+spec :: Spec
+spec = do
+  -- RFC 2202 Test Cases for HMAC-MD5 and HMAC-SHA-1
+  -- https://www.rfc-editor.org/rfc/rfc2202.html
+  describe "SCRAM crypto helpers" $ do
+    it "computes SHA1 digest" $ do
+      hex (hashBytes (Proxy :: Proxy Hash.SHA1) "abc")
+        `shouldBe` "a9993e364706816aba3e25717850c26c9cd0d89d"
+
+    it "computes HMAC-SHA1" $ do
+      hex (hmacBytes (Proxy :: Proxy Hash.SHA1) "Jefe" "what do ya want for nothing?")
+        `shouldBe` "effcdf6ae5eb2fa2d27416d5f184df9c259a7c79"
+
+hex :: BS.ByteString -> String
+hex = concatMap byteHex . BS.unpack
+
+byteHex :: Word8 -> String
+byteHex w =
+  if length str == 1 then '0' : str else str
+  where
+    str = showHex w ""


### PR DESCRIPTION
This replaces [deprecated `cryptohash`](https://hackage.haskell.org/package/cryptohash) with `crypton` (see: https://github.com/yesodweb/wai/pull/931, https://github.com/kazu-yamamoto/crypton/issues/5#issuecomment-1587161844 and https://github.com/commercialhaskell/stack/issues/6200 and https://github.com/commercialhaskell/stackage/issues/7474).

Changes tested in `Tests.Md5Digest` and `Tests.SaslCrypto` using `hash`, `hashRaw`, `md5Digest` export as `md5Hex`, `md5Raw`, `digestMd5Response`.